### PR TITLE
Test apicalls

### DIFF
--- a/src/Components/PaletteContainer/PaletteContainer.js
+++ b/src/Components/PaletteContainer/PaletteContainer.js
@@ -37,7 +37,8 @@ const PaletteContainer = ({ palette, name, id }) => {
   }
 
   const handlePatch = (palette, name, id, e) => {
-    patchPalette(palette, name, id)
+    let folderId = window.location.pathname.split('/')[2]
+    patchPalette(palette, name, id, folderId)
       .then(res => console.log(res))
       .then(data => console.log(data))
       .catch(error => console.error(error))

--- a/src/apiCalls/apiCalls.js
+++ b/src/apiCalls/apiCalls.js
@@ -14,7 +14,7 @@ export const getPalettes = (id) => {
   return fetch(url)
     .then(res => {
       if(!res.ok) {
-        throw Error('Failed fetching folders')
+        throw Error('Failed fetching palettes')
       }
       return res.json()})
 }

--- a/src/apiCalls/apiCalls.js
+++ b/src/apiCalls/apiCalls.js
@@ -38,9 +38,7 @@ export const postFolder = (folder) => {
     })
 }
 
-export const patchPalette = (palette, name, id) => {
-  let folderId = window.location.pathname.split('/')[2]
-  console.log(folderId)
+export const patchPalette = (palette, name, id, folderId) => {
   let url = process.env.REACT_APP_BACKEND_URL + `/api/v1/folders/${folderId}/palettes/${id}`
   const body = {
     palette_name: name,
@@ -63,7 +61,7 @@ export const patchPalette = (palette, name, id) => {
    return fetch(url, options)
     .then(res => {
       if (!res.ok){
-        throw Error('Error posting folder')
+        throw Error('Error updating palette')
       }
      return res.json()
    })

--- a/src/apiCalls/apiCalls.test.js
+++ b/src/apiCalls/apiCalls.test.js
@@ -114,7 +114,7 @@ describe('apiCalls', () => {
         })
       })
 
-      expect(getPalettes()).rejects.toEqual(Error('Failed fetching folders'))
+      expect(getPalettes()).rejects.toEqual(Error('Failed fetching palettes'))
     })
 
     it('should return an error if promise rejects', () => {
@@ -123,6 +123,59 @@ describe('apiCalls', () => {
       })
 
       expect(getPalettes()).rejects.toEqual(Error('fetch failed'))
+    })
+  })
+
+  describe('postFolder', () => {
+    let mockResponse, mockFolder, mockOptions
+    beforeEach(() => {
+      mockResponse = {id: 1}
+      mockFolder = {
+        folder_name: 'Colors out of Space'
+      }
+      mockOptions = {
+        method: 'POST',
+        body: JSON.stringify(mockFolder),
+        headers: {
+          'Content-Type': 'application/json'  
+        }
+      }
+  
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          json: () => {
+            return Promise.resolve(mockResponse)
+          }
+        })
+      })
+    })
+    it('should call fetch with the right url', () => {
+      let url = process.env.REACT_APP_BACKEND_URL + `/api/v1/folders/`
+      postFolder(mockFolder)
+      expect(window.fetch).toHaveBeenCalledWith(url, mockOptions)
+    })
+
+    it('return an id', () => {
+      expect(postFolder(mockFolder)).resolves.toEqual(mockResponse)
+    })
+
+    it('should throw an error if fetch fails', () => {
+      window.fetch = jest.fn().mockImplementation(()=> {
+        return Promise.resolve({
+          ok: false
+        })
+      })
+
+      expect(postFolder(mockFolder)).rejects.toEqual(Error('Error posting folder'))
+    })
+
+    it('should return an error if promise rejects', () => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.reject(Error('fetch failed'))
+      })
+
+      expect(postFolder(mockFolder)).rejects.toEqual(Error('fetch failed'))
     })
   })
 })

--- a/src/apiCalls/apiCalls.test.js
+++ b/src/apiCalls/apiCalls.test.js
@@ -25,7 +25,6 @@ describe('apiCalls', () => {
           json: () => Promise.resolve(mockResponse)
         })
       })
-
     })
 
     it('should call fetch with the correct url', () => {
@@ -36,6 +35,94 @@ describe('apiCalls', () => {
 
     it('should return an array of folders', () => {
       expect(getFolders()).resolves.toEqual(mockResponse)
+    })
+
+    it('should throw an error if fetch fails', () => {
+      window.fetch = jest.fn().mockImplementation(()=> {
+        return Promise.resolve({
+          ok: false
+        })
+      })
+
+      expect(getFolders()).rejects.toEqual(Error('Failed fetching folders'))
+    })
+
+    it('should return an error if promise rejects', () => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.reject(Error('fetch failed'))
+      })
+
+      expect(getFolders()).rejects.toEqual(Error('fetch failed'))
+    })
+  })
+
+  describe('getPalettes', () => {
+    let mockResponse = [
+       { id: 1,
+        palette_name: 'colors to make robbie blush', 
+        color_one: '#80adaa',
+        color_two: '#d9c9fb',
+        color_three: '#9c5f3d',
+        color_four: '#4ba9b3',
+        color_five: '#a6617c',
+        folder_id: 1 
+      },
+      { id: 2,
+        palette_name: 'colors to defeat trump', 
+        color_one: '#blue',
+        color_two: '#brown',
+        color_three: '#green',
+        color_four: '#ffffff',
+        color_five: '#11111',
+        folder_id: 2 
+      },
+      { id: 3,
+        palette_name: 'colors to grant yr wishes', 
+        color_one: '#blue',
+        color_two: '#brown',
+        color_three: '#green',
+        color_four: '#ffffff',
+        color_five: '#11111',
+        folder_id: 3 
+      }
+    ]
+
+    beforeEach(() => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockResponse)
+        })
+      })
+    })
+
+    it('should call fetch with the correct url', () => {
+      const mockFolderId = undefined
+      let url = `${process.env.REACT_APP_BACKEND_URL}/api/v1/folders/${mockFolderId}/palettes`;
+      getPalettes()
+      expect(window.fetch).toHaveBeenCalledWith(url)
+    })
+
+    it('should return an array of folders', () => {
+      expect(getPalettes()).resolves.toEqual(mockResponse)
+    })
+
+    it('should throw an error if fetch fails', () => {
+      window.fetch = jest.fn().mockImplementation(()=> {
+        return Promise.resolve({
+          ok: false
+        })
+      })
+
+      expect(getPalettes()).rejects.toEqual(Error('Failed fetching folders'))
+    })
+
+    it('should return an error if promise rejects', () => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.reject(Error('fetch failed'))
+      })
+
+      expect(getPalettes()).rejects.toEqual(Error('fetch failed'))
     })
   })
 })

--- a/src/apiCalls/apiCalls.test.js
+++ b/src/apiCalls/apiCalls.test.js
@@ -178,4 +178,72 @@ describe('apiCalls', () => {
       expect(postFolder(mockFolder)).rejects.toEqual(Error('fetch failed'))
     })
   })
+
+  describe('postPalette', () => {
+    let mockResponse, mockPalette, mockOptions, mockFolderId
+    beforeEach(() => {
+      mockResponse = { id: 2,
+        palette_name: 'colors to defeat trump', 
+        color_one: '#blue',
+        color_two: '#brown',
+        color_three: '#green',
+        color_four: '#ffffff',
+        color_five: '#11111',
+        folder_id: 2 
+      }
+      mockPalette = { id: 2,
+        palette_name: 'colors to defeat trump', 
+        color_one: '#blue',
+        color_two: '#brown',
+        color_three: '#green',
+        color_four: '#ffffff',
+        color_five: '#11111',
+        folder_id: 2 
+      }
+      mockOptions = {
+        method: 'POST',
+        body: JSON.stringify(mockPalette),
+        headers: {
+          'Content-Type': 'application/json'  
+        }
+      }
+      mockFolderId = 1
+  
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          json: () => {
+            return Promise.resolve(mockResponse)
+          }
+        })
+      })
+    })
+    it('should call fetch with the right url', () => {
+      let url = process.env.REACT_APP_BACKEND_URL + `/api/v1/folders/${mockFolderId}/palettes`
+      postPalette(mockPalette, mockFolderId)
+      expect(window.fetch).toHaveBeenCalledWith(url, mockOptions)
+    })
+
+    it('return an id', () => {
+      expect(postPalette(mockPalette, mockFolderId)).resolves.toEqual(mockResponse)
+    })
+
+    it('should throw an error if fetch fails', () => {
+      window.fetch = jest.fn().mockImplementation(()=> {
+        return Promise.resolve({
+          ok: false
+        })
+      })
+
+      expect(postPalette(mockPalette, mockFolderId)).rejects.toEqual(Error('Error posting folder'))
+    })
+
+    it('should return an error if promise rejects', () => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.reject(Error('fetch failed'))
+      })
+
+      expect(postPalette(mockPalette, mockFolderId)).rejects.toEqual(Error('fetch failed'))
+    })
+  })
 })

--- a/src/apiCalls/apiCalls.test.js
+++ b/src/apiCalls/apiCalls.test.js
@@ -1,0 +1,41 @@
+
+import { getFolders, getPalettes, postFolder, patchPalette, postPalette }from './apiCalls';
+
+describe('apiCalls', () => {
+
+  describe('getFolders', () => {
+    let mockResponse = [
+      {
+        id: 1,
+        folder_name: 'colors to win 2020',
+      },
+      {
+        id: 2,
+        folder_name: 'colors of the old gods',
+      },{
+        id: 3,
+        folder_name: 'kanye test folder',
+      }
+    ]
+    
+    beforeEach(() => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockResponse)
+        })
+      })
+
+    })
+
+    it('should call fetch with the correct url', () => {
+      let url = process.env.REACT_APP_BACKEND_URL + '/api/v1/folders'
+      getFolders()
+      expect(window.fetch).toHaveBeenCalledWith(url)
+    })
+
+    it('should return an array of folders', () => {
+      expect(getFolders()).resolves.toEqual(mockResponse)
+    })
+  })
+})

--- a/src/apiCalls/apiCalls.test.js
+++ b/src/apiCalls/apiCalls.test.js
@@ -1,4 +1,3 @@
-
 import { getFolders, getPalettes, postFolder, patchPalette, postPalette }from './apiCalls';
 
 describe('apiCalls', () => {
@@ -176,6 +175,81 @@ describe('apiCalls', () => {
       })
 
       expect(postFolder(mockFolder)).rejects.toEqual(Error('fetch failed'))
+    })
+  })
+
+  describe('patchPalette', () => {
+    let mockResponse, mockPalette, mockOptions, mockFolderId, mockPaletteId, mockName
+    
+    beforeEach(() => {
+      mockFolderId = 2
+      mockPaletteId = 2
+      
+      mockResponse = {
+        palette_name: 'colors to defeat capitalism', 
+        color_one: '#blue',
+        color_two: '#brown',
+        color_three: '#green',
+        color_four: '#ffffff',
+        color_five: '#111111',
+        folder_id: mockFolderId
+      }
+
+      mockName = 'colors to defeat capitalism'
+
+      mockPalette = [
+        { color: '#blue' },
+        { color: '#brown' },
+        { color: '#green' },
+        { color: '#ffffff' },
+        { color: '#111111' }
+      ]
+
+      mockOptions = {
+        method: 'PATCH',
+        body: JSON.stringify(mockResponse),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+
+      
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.resolve({
+          ok: true,
+          json: () => {
+            return Promise.resolve(mockResponse)
+          }
+        })
+      })
+    })
+      
+    it('should call fetch with the right url', () => {
+      let url = process.env.REACT_APP_BACKEND_URL + `/api/v1/folders/${mockFolderId}/palettes/${mockPaletteId}`
+      patchPalette(mockPalette, mockName, mockPaletteId, mockFolderId)
+      expect(window.fetch).toHaveBeenCalledWith(url, mockOptions)
+    })
+
+    it('return the updated palette', () => {
+      expect(patchPalette(mockPalette, mockName, mockPaletteId, mockFolderId)).resolves.toEqual(mockResponse)
+    })
+
+    it('should throw an error if fetch fails', () => {
+      window.fetch = jest.fn().mockImplementation(()=> {
+        return Promise.resolve({
+          ok: false
+        })
+      })
+
+      expect(patchPalette(mockPalette, mockName, mockPaletteId, mockFolderId)).rejects.toEqual(Error('Error updating palette'))
+    })
+
+    it('should return an error if promise rejects', () => {
+      window.fetch = jest.fn().mockImplementation(() => {
+        return Promise.reject(Error('fetch failed'))
+      })
+
+      expect(patchPalette(mockPalette, mockName, mockPaletteId, mockFolderId)).rejects.toEqual(Error('fetch failed'))
     })
   })
 


### PR DESCRIPTION
#### What's this PR do?
- The PR adds happy and sad path testing for all existing api calls.
- It also refactors the patchPalette api call to take in a folderId
#### Where should the reviewer start?
- apiCalls.test.js, look at all the sad and happy path tests for each endpoint
#### How should this be manually tested?
- run npm test